### PR TITLE
Remove redundant util methods

### DIFF
--- a/src/net/kettlemc/discordbridge/discord/DiscordBot.java
+++ b/src/net/kettlemc/discordbridge/discord/DiscordBot.java
@@ -13,9 +13,11 @@ import net.kettlemc.discordbridge.discord.command.SlashCommandListener;
 import net.kettlemc.discordbridge.discord.command.commands.ListSlashCommand;
 import net.kettlemc.discordbridge.discord.command.commands.StopServerCommand;
 import net.kettlemc.discordbridge.discord.listener.MessageListener;
-import net.kettlemc.discordbridge.utils.Utils;
 
 import javax.security.auth.login.LoginException;
+
+import org.bukkit.Bukkit;
+
 import java.util.List;
 
 public class DiscordBot {
@@ -26,7 +28,7 @@ public class DiscordBot {
         try {
 
             JDABuilder builder = JDABuilder.createDefault(DiscordConfig.DISCORD_TOKEN.getValue());
-            builder.setActivity(Activity.playing(DiscordConfig.DISCORD_BOT_STATUS.getValue().replace("%online%", String.valueOf(Utils.getPlayerSize()))));
+            builder.setActivity(Activity.playing(DiscordConfig.DISCORD_BOT_STATUS.getValue().replace("%online%", String.valueOf(Bukkit.getOnlinePlayers().size()))));
             builder.setStatus(OnlineStatus.ONLINE);
             this.jda = builder.build();
 
@@ -88,7 +90,7 @@ public class DiscordBot {
     }
 
     public void updateStatus() {
-        String status = DiscordConfig.DISCORD_BOT_STATUS.getValue().replace("%online%", String.valueOf(Utils.getPlayerSize()));
+        String status = DiscordConfig.DISCORD_BOT_STATUS.getValue().replace("%online%", String.valueOf(Bukkit.getOnlinePlayers().size()));
         this.getJDA().getPresence().setActivity(Activity.playing(status));
     }
 }

--- a/src/net/kettlemc/discordbridge/discord/command/commands/ListSlashCommand.java
+++ b/src/net/kettlemc/discordbridge/discord/command/commands/ListSlashCommand.java
@@ -5,9 +5,9 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
+import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import net.kettlemc.discordbridge.config.DiscordConfig;
 import net.kettlemc.discordbridge.discord.command.SlashCommand;
-import net.kettlemc.discordbridge.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -28,7 +28,7 @@ public class ListSlashCommand extends SlashCommand {
             count++;
         }
 
-        String playerList = DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? Utils.replaceFormats(players.toString()) : players.toString();
+        String playerList = DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? MarkdownSanitizer.escape(players.toString(), true) : players.toString();
 
         if (count != 0) {
             event.reply(DiscordConfig.DISCORD_MESSAGE_ONLINE_LIST.getValue().replace("%players%", playerList).replace("%online%", String.valueOf(count))).queue();

--- a/src/net/kettlemc/discordbridge/listener/AsyncChatListener.java
+++ b/src/net/kettlemc/discordbridge/listener/AsyncChatListener.java
@@ -1,5 +1,6 @@
 package net.kettlemc.discordbridge.listener;
 
+import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import net.kettlemc.discordbridge.DiscordBridge;
 import net.kettlemc.discordbridge.config.DiscordConfig;
 import net.kettlemc.discordbridge.utils.Utils;
@@ -20,10 +21,10 @@ public class AsyncChatListener implements Listener {
         }
 
         String name = event.getPlayer().getDisplayName();
-        name = (DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? Utils.replaceFormats(name) : name);
+        name = (DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? MarkdownSanitizer.escape(name, true) : name);
 
         String msg = Utils.stripColor(event.getMessage());
-        msg = (DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? Utils.replaceFormats(msg) : msg);
+        msg = (DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? MarkdownSanitizer.escape(msg, true) : msg);
 
 
         String message = DiscordConfig.DISCORD_MESSAGE_CHAT.getValue().replace("%rank%", prefix).replace("%player%", name).replace("%msg%", msg);

--- a/src/net/kettlemc/discordbridge/listener/JoinQuitListener.java
+++ b/src/net/kettlemc/discordbridge/listener/JoinQuitListener.java
@@ -1,5 +1,6 @@
 package net.kettlemc.discordbridge.listener;
 
+import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import net.kettlemc.discordbridge.DiscordBridge;
 import net.kettlemc.discordbridge.config.DiscordConfig;
 import net.kettlemc.discordbridge.utils.Utils;
@@ -13,7 +14,7 @@ public class JoinQuitListener implements Listener {
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
         String message = Utils.stripColor(event.getJoinMessage());
-        message =  (DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? Utils.replaceFormats(message) : message);
+        message =  (DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? MarkdownSanitizer.escape(message, true) : message);
         DiscordBridge.getInstance().getBot().sendMessage(DiscordConfig.DISCORD_MESSAGE_JOIN.getValue().replace("%msg%", message));
         DiscordBridge.getInstance().getBot().updateStatus();
     }
@@ -21,7 +22,7 @@ public class JoinQuitListener implements Listener {
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
         String message = Utils.stripColor(event.getQuitMessage());
-        message =  (DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? Utils.replaceFormats(message) : message);
+        message =  (DiscordConfig.DISCORD_DISABLE_FORMATTING.getValue() ? MarkdownSanitizer.escape(message, true) : message);
         DiscordBridge.getInstance().getBot().sendMessage(DiscordConfig.DISCORD_MESSAGE_QUIT.getValue().replace("%msg%", message));
         DiscordBridge.getInstance().getBot().updateStatus();
     }

--- a/src/net/kettlemc/discordbridge/utils/Utils.java
+++ b/src/net/kettlemc/discordbridge/utils/Utils.java
@@ -3,7 +3,6 @@ package net.kettlemc.discordbridge.utils;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.model.user.User;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.regex.Pattern;
@@ -36,13 +35,4 @@ public class Utils {
             string = string.replace(str, "\\" + str);
         return string;
     }
-
-    public static int getPlayerSize() {
-        int count = 0;
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            count++;
-        }
-        return count;
-    }
-
 }

--- a/src/net/kettlemc/discordbridge/utils/Utils.java
+++ b/src/net/kettlemc/discordbridge/utils/Utils.java
@@ -9,8 +9,6 @@ import java.util.regex.Pattern;
 
 public class Utils {
 
-    private static final String[] FORMAT_CHARS = {"*", "_", "~", "`"};
-
     private static LuckPerms luckperms = LuckPermsProvider.get();
 
     public static String getLuckPermsPrefix(Player player) {
@@ -27,12 +25,5 @@ public class Utils {
         }
 
         return COLOR_PATTERN.matcher(input).replaceAll("");
-    }
-
-    // replaces all format chars with their non-formatting version
-    public static String replaceFormats(String string) {
-        for (String str : FORMAT_CHARS)
-            string = string.replace(str, "\\" + str);
-        return string;
     }
 }


### PR DESCRIPTION
Replaces `Utils#getPlayerSize` with `Bukkit.getOnlinePlayers().size()` and uses JDA's `MarkdownSanitizer` instead of `Utils#replaceFormats`. A positive side effect is that `MarkdownSanitizer` escapes spoilers while `Utils#replaceFormats` did not.